### PR TITLE
Added default charset

### DIFF
--- a/src/random_string.rs
+++ b/src/random_string.rs
@@ -5,3 +5,5 @@ mod generator;
 
 #[allow(unused_imports)]
 pub use generator::*;
+
+pub const default_charset: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";


### PR DESCRIPTION
Providing a handy set of default ASCII characters instead of having to provide a charset manually every time.